### PR TITLE
Add option types to the GraphQL schema.

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ type Answer {
     label: String
     type: AnswerType
     mandatory: Boolean
+    options: [Option]
     questionPageId: Int
 }
 

--- a/index.js
+++ b/index.js
@@ -49,6 +49,16 @@ type Answer {
     questionPageId: Int
 }
 
+type Option {
+    id: Int
+    label: String
+    description: String
+    value: String
+    qCode: String
+    childAnswerId: Int
+    answerId: Int
+}
+
 enum PageType {
   QuestionPage
   InterstitialPage
@@ -93,6 +103,7 @@ type Query {
     page(id: Int!): Page
     questionPage(id: Int!): QuestionPage
     answer(id: Int!): Answer
+    option(id: Int!): Option
 }
 
 type Mutation {
@@ -119,5 +130,9 @@ type Mutation {
     createAnswer(description: String, guidance: String, label: String, qCode: String, type: AnswerType!, mandatory: Boolean!, questionPageId: Int!) : Answer
     updateAnswer(id: Int!, description: String, guidance: String, label: String, qCode: String, type: AnswerType, mandatory: Boolean) : Answer
     deleteAnswer(id: Int!) : Answer
+    
+    createOption(label: String, description: String, value: String, qCode: String, childAnswerId: Int, answerId: Int!) : Option
+    updateOption(id: Int!, label: String, description: String, value: String, qCode: String, childAnswerId: Int) : Option
+    deleteOption(id: Int!) : Option
 }
 `;


### PR DESCRIPTION
### What is the context of this PR?
This PR extends the GraphQL schema to include Option type.
Options are attached to an answer.

### How to review 
The updates to the GraphQL schema are correct. The mock API implementation behaves as expected.
