### PR TITLE
Introduce interface and concrete types for answers.

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,29 @@ type QuestionPage implements Page {
     sectionId: Int!
 }
 
-type Answer {
+interface Answer {
+    id: Int
+    description: String
+    guidance: String
+    qCode: String
+    label: String
+    type: AnswerType
+    mandatory: Boolean
+    questionPageId: Int
+}
+
+type BasicAnswer implements Answer {
+    id: Int
+    description: String
+    guidance: String
+    qCode: String
+    label: String
+    type: AnswerType
+    mandatory: Boolean
+    questionPageId: Int
+}
+
+type MultipleChoiceAnswer implements Answer {
     id: Int
     description: String
     guidance: String

--- a/index.js
+++ b/index.js
@@ -39,41 +39,41 @@ type QuestionPage implements Page {
 }
 
 interface Answer {
-    id: Int
+    id: Int!
     description: String
     guidance: String
     qCode: String
     label: String
-    type: AnswerType
+    type: AnswerType!
     mandatory: Boolean
     questionPageId: Int
 }
 
 type BasicAnswer implements Answer {
-    id: Int
+    id: Int!
     description: String
     guidance: String
     qCode: String
     label: String
-    type: AnswerType
+    type: AnswerType!
     mandatory: Boolean
     questionPageId: Int
 }
 
 type MultipleChoiceAnswer implements Answer {
-    id: Int
+    id: Int!
     description: String
     guidance: String
     qCode: String
     label: String
-    type: AnswerType
+    type: AnswerType!
     mandatory: Boolean
     options: [Option]
     questionPageId: Int
 }
 
 type Option {
-    id: Int
+    id: Int!
     label: String
     description: String
     value: String

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ interface Answer {
     label: String
     type: AnswerType!
     mandatory: Boolean
-    questionPageId: Int
+    questionPageId: Int!
 }
 
 type BasicAnswer implements Answer {
@@ -57,7 +57,7 @@ type BasicAnswer implements Answer {
     label: String
     type: AnswerType!
     mandatory: Boolean
-    questionPageId: Int
+    questionPageId: Int!
 }
 
 type MultipleChoiceAnswer implements Answer {
@@ -69,7 +69,7 @@ type MultipleChoiceAnswer implements Answer {
     type: AnswerType!
     mandatory: Boolean
     options: [Option]
-    questionPageId: Int
+    questionPageId: Int!
 }
 
 type Option {
@@ -79,7 +79,7 @@ type Option {
     value: String
     qCode: String
     childAnswerId: Int
-    answerId: Int
+    answerId: Int!
 }
 
 enum PageType {


### PR DESCRIPTION
### What is the context of this PR?
This PR builds on the previous change of introducing Option type for Answers by further restricting Options to MultipleChoiceAnswers.
That is, only Radio and Checkbox Answers should currently support returning Options. This PR enforces this in the Schema.
A separate PR will be raised to change the resolvers in the API.

### How to review 
The GraphQL schema should be correct and work with the updated API resolvers.
