### PR TITLE
Remove mandatory from Question type

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,6 @@ type QuestionPage implements Page {
     guidance: String
     pageType: PageType!
     type: QuestionType!
-    mandatory: Boolean
     answers:  [Answer]
     sectionId: Int! @deprecated(reason: "use 'section' instead")
     section: Section
@@ -153,8 +152,8 @@ type Mutation {
     updatePage(id: Int!, title: String!, description: String) : Page
     deletePage(id: Int!) : Page
 
-    createQuestionPage(title: String!, description: String, guidance: String, type: QuestionType!, mandatory: Boolean, sectionId: Int!) : QuestionPage
-    updateQuestionPage(id: Int!, title: String, description: String, guidance: String, type: QuestionType, mandatory: Boolean) : QuestionPage
+    createQuestionPage(title: String!, description: String, guidance: String, type: QuestionType!, sectionId: Int!) : QuestionPage
+    updateQuestionPage(id: Int!, title: String, description: String, guidance: String, type: QuestionType) : QuestionPage
     deleteQuestionPage(id: Int!) : QuestionPage
 
     createAnswer(description: String, guidance: String, label: String, qCode: String, type: AnswerType!, mandatory: Boolean!, questionPageId: Int!) : Answer


### PR DESCRIPTION
### What is the context of this PR?
Update the schema to remove all references to the mandatory field from the QuestionPage type and associated mutations.

### How to review 
There should no longer be any references to mandatory on the QuestionPage type and mutations.
This PR supports changes made in https://github.com/ONSdigital/eq-author-api/pull/30.