### PR TITLE
Improve graphql usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 module.exports = `
-
 scalar Date
 
 type Questionnaire {
     id: Int
+    newId: ID
     title: String
     description: String
     theme: Theme
@@ -16,6 +16,7 @@ type Questionnaire {
 
 type Section {
     id: Int
+    newId: ID
     title: String!
     description: String
     pages: [Page]
@@ -24,6 +25,7 @@ type Section {
 
 interface Page {
     id: Int!
+    newId: ID
     title: String!
     description: String
     pageType: PageType!
@@ -32,6 +34,7 @@ interface Page {
 
 type QuestionPage implements Page {
     id: Int!
+    newId: ID
     title: String!
     description: String!
     guidance: String
@@ -42,6 +45,7 @@ type QuestionPage implements Page {
 
 interface Answer {
     id: Int!
+    newId: ID
     description: String
     guidance: String
     qCode: String
@@ -53,6 +57,7 @@ interface Answer {
 
 type BasicAnswer implements Answer {
     id: Int!
+    newId: ID
     description: String
     guidance: String
     qCode: String
@@ -64,6 +69,7 @@ type BasicAnswer implements Answer {
 
 type MultipleChoiceAnswer implements Answer {
     id: Int!
+    newId: ID
     description: String
     guidance: String
     qCode: String
@@ -76,6 +82,7 @@ type MultipleChoiceAnswer implements Answer {
 
 type Option {
     id: Int!
+    newId: ID
     label: String
     description: String
     value: String
@@ -114,12 +121,12 @@ enum Theme {
 
 type Query {
     questionnaires: [Questionnaire]
-    questionnaire(id: Int!): Questionnaire
-    section(id: Int!): Section
-    page(id: Int!): Page
-    questionPage(id: Int!): QuestionPage
-    answer(id: Int!): Answer
-    option(id: Int!): Option
+    questionnaire(id: Int, newId: ID): Questionnaire
+    section(id: Int, newId: ID): Section
+    page(id: Int, newId: ID): Page
+    questionPage(id: Int, newId: ID): QuestionPage
+    answer(id: Int, newId: ID): Answer
+    option(id: Int, newId: ID): Option
 }
 
 type Mutation {

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ type Section {
 }
 
 interface Page {
-    id: Int!
+    id: Int
     newId: ID
     title: String!
     description: String
@@ -33,7 +33,7 @@ interface Page {
 }
 
 type QuestionPage implements Page {
-    id: Int!
+    id: Int
     newId: ID
     title: String!
     description: String!
@@ -44,7 +44,7 @@ type QuestionPage implements Page {
 }
 
 interface Answer {
-    id: Int!
+    id: Int
     newId: ID
     description: String
     guidance: String
@@ -56,7 +56,7 @@ interface Answer {
 }
 
 type BasicAnswer implements Answer {
-    id: Int!
+    id: Int
     newId: ID
     description: String
     guidance: String
@@ -68,7 +68,7 @@ type BasicAnswer implements Answer {
 }
 
 type MultipleChoiceAnswer implements Answer {
-    id: Int!
+    id: Int
     newId: ID
     description: String
     guidance: String
@@ -81,7 +81,7 @@ type MultipleChoiceAnswer implements Answer {
 }
 
 type Option {
-    id: Int!
+    id: Int
     newId: ID
     label: String
     description: String

--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@ type Questionnaire {
     surveyId: String
     createdAt: Date
     sections: [Section]
-    groups: [Section] @deprecated(reason: "use 'sections' instead")
 }
 
 type Section {
@@ -20,7 +19,6 @@ type Section {
     title: String!
     description: String
     pages: [Page]
-    questionnaireId: Int! @deprecated(reason: "use 'questionnaire' instead")
     questionnaire: Questionnaire
 }
 
@@ -29,7 +27,6 @@ interface Page {
     title: String!
     description: String
     pageType: PageType!
-    sectionId: Int! @deprecated(reason: "use 'section' instead")
     section: Section
 }
 
@@ -40,7 +37,6 @@ type QuestionPage implements Page {
     guidance: String
     pageType: PageType!
     answers:  [Answer]
-    sectionId: Int! @deprecated(reason: "use 'section' instead")
     section: Section
 }
 
@@ -52,7 +48,6 @@ interface Answer {
     label: String
     type: AnswerType!
     mandatory: Boolean
-    questionPageId: Int! @deprecated(reason: "use 'page' instead")
     page: QuestionPage
 }
 
@@ -64,7 +59,6 @@ type BasicAnswer implements Answer {
     label: String
     type: AnswerType!
     mandatory: Boolean
-    questionPageId: Int! @deprecated(reason: "use 'page' instead")
     page: QuestionPage
 }
 
@@ -77,7 +71,6 @@ type MultipleChoiceAnswer implements Answer {
     type: AnswerType!
     mandatory: Boolean
     options: [Option]
-    questionPageId: Int! @deprecated(reason: "use 'page' instead")
     page: QuestionPage
 }
 
@@ -88,7 +81,6 @@ type Option {
     value: String
     qCode: String
     childAnswerId: Int
-    answerId: Int! @deprecated(reason: "use 'answer' instead")
     answer: Answer
 }
 
@@ -124,7 +116,6 @@ type Query {
     questionnaires: [Questionnaire]
     questionnaire(id: Int!): Questionnaire
     section(id: Int!): Section
-    group(id: Int!): Section @deprecated(reason: "use 'section' instead")
     page(id: Int!): Page
     questionPage(id: Int!): QuestionPage
     answer(id: Int!): Answer
@@ -140,9 +131,6 @@ type Mutation {
     createSection(title: String!, description: String, questionnaireId: Int!) : Section
     updateSection(id: Int!, title: String, description: String) : Section
     deleteSection(id: Int!) : Section
-    createGroup(title: String!, description: String, questionnaireId: Int!) : Section @deprecated(reason: "use 'createSection' instead")
-    updateGroup(id: Int!, title: String, description: String) : Section @deprecated(reason: "use 'updateSection' instead")
-    deleteGroup(id: Int!) : Section @deprecated(reason: "use 'deleteSection' instead")
 
     createPage(title: String!, description: String, sectionId: Int!) : Page
     updatePage(id: Int!, title: String!, description: String) : Page

--- a/index.js
+++ b/index.js
@@ -2,93 +2,93 @@ module.exports = `
 scalar Date
 
 type Questionnaire {
-    id: Int
-    newId: ID
-    title: String
-    description: String
-    theme: Theme
-    legalBasis: LegalBasis
-    navigation: Boolean
-    surveyId: String
-    createdAt: Date
-    sections: [Section]
+  id: Int
+  newId: ID
+  title: String
+  description: String
+  theme: Theme
+  legalBasis: LegalBasis
+  navigation: Boolean
+  surveyId: String
+  createdAt: Date
+  sections: [Section]
 }
 
 type Section {
-    id: Int
-    newId: ID
-    title: String!
-    description: String
-    pages: [Page]
-    questionnaire: Questionnaire
+  id: Int
+  newId: ID
+  title: String!
+  description: String
+  pages: [Page]
+  questionnaire: Questionnaire
 }
 
 interface Page {
-    id: Int
-    newId: ID
-    title: String!
-    description: String
-    pageType: PageType!
-    section: Section
+  id: Int
+  newId: ID
+  title: String!
+  description: String
+  pageType: PageType!
+  section: Section
 }
 
 type QuestionPage implements Page {
-    id: Int
-    newId: ID
-    title: String!
-    description: String!
-    guidance: String
-    pageType: PageType!
-    answers:  [Answer]
-    section: Section
+  id: Int
+  newId: ID
+  title: String!
+  description: String!
+  guidance: String
+  pageType: PageType!
+  answers: [Answer]
+  section: Section
 }
 
 interface Answer {
-    id: Int
-    newId: ID
-    description: String
-    guidance: String
-    qCode: String
-    label: String
-    type: AnswerType!
-    mandatory: Boolean
-    page: QuestionPage
+  id: Int
+  newId: ID
+  description: String
+  guidance: String
+  qCode: String
+  label: String
+  type: AnswerType!
+  mandatory: Boolean
+  page: QuestionPage
 }
 
 type BasicAnswer implements Answer {
-    id: Int
-    newId: ID
-    description: String
-    guidance: String
-    qCode: String
-    label: String
-    type: AnswerType!
-    mandatory: Boolean
-    page: QuestionPage
+  id: Int
+  newId: ID
+  description: String
+  guidance: String
+  qCode: String
+  label: String
+  type: AnswerType!
+  mandatory: Boolean
+  page: QuestionPage
 }
 
 type MultipleChoiceAnswer implements Answer {
-    id: Int
-    newId: ID
-    description: String
-    guidance: String
-    qCode: String
-    label: String
-    type: AnswerType!
-    mandatory: Boolean
-    options: [Option]
-    page: QuestionPage
+  id: Int
+  newId: ID
+  description: String
+  guidance: String
+  qCode: String
+  label: String
+  type: AnswerType!
+  mandatory: Boolean
+  options: [Option]
+  page: QuestionPage
 }
 
 type Option {
-    id: Int
-    newId: ID
-    label: String
-    description: String
-    value: String
-    qCode: String
-    childAnswerId: Int
-    answer: Answer
+  id: Int
+  newId: ID
+  label: String
+  description: String
+  value: String
+  qCode: String
+  childAnswerId: Int
+  answer: Answer
 }
 
 enum PageType {
@@ -97,182 +97,260 @@ enum PageType {
 }
 
 enum AnswerType {
-    Checkbox
-    Currency
-    Date
-    MonthYearDate
-    Number
-    Percentage
-    Radio
-    TextArea
-    TextField
-    Relationship
+  Checkbox
+  Currency
+  Date
+  MonthYearDate
+  Number
+  Percentage
+  Radio
+  TextArea
+  TextField
+  Relationship
 }
 
 enum LegalBasis {
-    Voluntary
-    StatisticsOfTradeAct
+  Voluntary
+  StatisticsOfTradeAct
 }
 
 enum Theme {
-    default
-    census
+  default
+  census
 }
 
 type Query {
-    questionnaires: [Questionnaire]
-    questionnaire(id: Int, newId: ID): Questionnaire
-    section(id: Int, newId: ID): Section
-    page(id: Int, newId: ID): Page
-    questionPage(id: Int, newId: ID): QuestionPage
-    answer(id: Int, newId: ID): Answer
-    option(id: Int, newId: ID): Option
+  questionnaires: [Questionnaire]
+  questionnaire(id: Int, newId: ID): Questionnaire
+  section(id: Int, newId: ID): Section
+  page(id: Int, newId: ID): Page
+  questionPage(id: Int, newId: ID): QuestionPage
+  answer(id: Int, newId: ID): Answer
+  option(id: Int, newId: ID): Option
 }
 
 type Mutation {
-    # creates a Questionnaire along with an initial Section and Page
-    createQuestionnaire(title: String, description: String, theme: String, legalBasis: LegalBasis, navigation: Boolean, surveyId: String, input: CreateQuestionnaireInput) : Questionnaire
-    updateQuestionnaire(id: Int, title: String, description: String, theme: String, legalBasis: LegalBasis, navigation: Boolean, surveyId: String, input: UpdateQuestionnaireInput) : Questionnaire
-    deleteQuestionnaire(id: Int, input: DeleteQuestionnaireInput) : Questionnaire
-
-    createSection(title: String, description: String, questionnaireId: Int, input: CreateSectionInput) : Section
-    updateSection(id: Int, title: String, description: String, input: UpdateSectionInput) : Section
-    deleteSection(id: Int, input: DeleteSectionInput) : Section
-
-    createPage(title: String, description: String, sectionId: Int, input: CreatePageInput) : Page
-    updatePage(id: Int, title: String, description: String, input: UpdatePageInput) : Page
-    deletePage(id: Int, input: DeletePageInput) : Page
-
-    createQuestionPage(title: String, description: String, guidance: String, sectionId: Int, input: CreateQuestionPageInput) : QuestionPage
-    updateQuestionPage(id: Int, title: String, description: String, guidance: String, input: UpdateQuestionPageInput) : QuestionPage
-    deleteQuestionPage(id: Int, input: DeleteQuestionPageInput) : QuestionPage
-
-    createAnswer(description: String, guidance: String, label: String, qCode: String, type: AnswerType, mandatory: Boolean, questionPageId: Int, input: CreateAnswerInput) : Answer
-    updateAnswer(id: Int, description: String, guidance: String, label: String, qCode: String, type: AnswerType, mandatory: Boolean, input: UpdateAnswerInput) : Answer
-    deleteAnswer(id: Int, input: DeleteAnswerInput) : Answer
-    
-    createOption(label: String, description: String, value: String, qCode: String, childAnswerId: Int, answerId: Int, input: CreateOptionInput) : Option
-    updateOption(id: Int, label: String, description: String, value: String, qCode: String, childAnswerId: Int, input: UpdateOptionInput) : Option
-    deleteOption(id: Int, input: DeleteOptionInput) : Option
-}
-
-
-input CreateQuestionnaireInput {
-    title: String!
-    description: String
-    theme: String!
-    legalBasis: LegalBasis!
-    navigation: Boolean
-    surveyId: String!
-}
-
-input UpdateQuestionnaireInput {
-    id: ID!
+  # creates a Questionnaire along with an initial Section and Page
+  createQuestionnaire(
     title: String
     description: String
     theme: String
     legalBasis: LegalBasis
     navigation: Boolean
     surveyId: String
-}
-
-input DeleteQuestionnaireInput {
-    id: ID!
-}
-
-input CreateSectionInput {
-    title: String!
-    description: String
-    questionnaireId: ID!
-}
-
-input UpdateSectionInput {
-    id: ID!
+    input: CreateQuestionnaireInput
+  ): Questionnaire
+  updateQuestionnaire(
+    id: Int
     title: String
     description: String
-}
-
-input DeleteSectionInput {
-    id: ID!
-}
-
-input CreatePageInput {
-    title: String!
+    theme: String
+    legalBasis: LegalBasis
+    navigation: Boolean
+    surveyId: String
+    input: UpdateQuestionnaireInput
+  ): Questionnaire
+  deleteQuestionnaire(id: Int, input: DeleteQuestionnaireInput): Questionnaire
+  createSection(
+    title: String
     description: String
-    sectionId: ID!
-}
-
-input UpdatePageInput {
-    id: ID!
-    title: String!
+    questionnaireId: Int
+    input: CreateSectionInput
+  ): Section
+  updateSection(
+    id: Int
+    title: String
     description: String
-}
-
-input DeletePageInput {
-    id: ID!
-}
-
-input CreateQuestionPageInput {
-    title: String!
+    input: UpdateSectionInput
+  ): Section
+  deleteSection(id: Int, input: DeleteSectionInput): Section
+  createPage(
+    title: String
     description: String
-    guidance: String
-    sectionId: ID!
-}
-
-input UpdateQuestionPageInput {
-    id: ID!
+    sectionId: Int
+    input: CreatePageInput
+  ): Page
+  updatePage(
+    id: Int
+    title: String
+    description: String
+    input: UpdatePageInput
+  ): Page
+  deletePage(id: Int, input: DeletePageInput): Page
+  createQuestionPage(
     title: String
     description: String
     guidance: String
-}
-
-input DeleteQuestionPageInput {
-    id: ID!
-}
-
-input CreateAnswerInput {
+    sectionId: Int
+    input: CreateQuestionPageInput
+  ): QuestionPage
+  updateQuestionPage(
+    id: Int
+    title: String
     description: String
     guidance: String
-    label: String
-    qCode: String
-    type: AnswerType!
-    mandatory: Boolean!
-    questionPageId: ID!
-}
-
-input UpdateAnswerInput {
-    id: ID!
+    input: UpdateQuestionPageInput
+  ): QuestionPage
+  deleteQuestionPage(id: Int, input: DeleteQuestionPageInput): QuestionPage
+  createAnswer(
     description: String
     guidance: String
     label: String
     qCode: String
     type: AnswerType
     mandatory: Boolean
+    questionPageId: Int
+    input: CreateAnswerInput
+  ): Answer
+  updateAnswer(
+    id: Int
+    description: String
+    guidance: String
+    label: String
+    qCode: String
+    type: AnswerType
+    mandatory: Boolean
+    input: UpdateAnswerInput
+  ): Answer
+  deleteAnswer(id: Int, input: DeleteAnswerInput): Answer
+  createOption(
+    label: String
+    description: String
+    value: String
+    qCode: String
+    childAnswerId: Int
+    answerId: Int
+    input: CreateOptionInput
+  ): Option
+  updateOption(
+    id: Int
+    label: String
+    description: String
+    value: String
+    qCode: String
+    childAnswerId: Int
+    input: UpdateOptionInput
+  ): Option
+  deleteOption(id: Int, input: DeleteOptionInput): Option
+}
+
+input CreateQuestionnaireInput {
+  title: String!
+  description: String
+  theme: String!
+  legalBasis: LegalBasis!
+  navigation: Boolean
+  surveyId: String!
+}
+
+input UpdateQuestionnaireInput {
+  id: ID!
+  title: String
+  description: String
+  theme: String
+  legalBasis: LegalBasis
+  navigation: Boolean
+  surveyId: String
+}
+
+input DeleteQuestionnaireInput {
+  id: ID!
+}
+
+input CreateSectionInput {
+  title: String!
+  description: String
+  questionnaireId: ID!
+}
+
+input UpdateSectionInput {
+  id: ID!
+  title: String
+  description: String
+}
+
+input DeleteSectionInput {
+  id: ID!
+}
+
+input CreatePageInput {
+  title: String!
+  description: String
+  sectionId: ID!
+}
+
+input UpdatePageInput {
+  id: ID!
+  title: String!
+  description: String
+}
+
+input DeletePageInput {
+  id: ID!
+}
+
+input CreateQuestionPageInput {
+  title: String!
+  description: String
+  guidance: String
+  sectionId: ID!
+}
+
+input UpdateQuestionPageInput {
+  id: ID!
+  title: String
+  description: String
+  guidance: String
+}
+
+input DeleteQuestionPageInput {
+  id: ID!
+}
+
+input CreateAnswerInput {
+  description: String
+  guidance: String
+  label: String
+  qCode: String
+  type: AnswerType!
+  mandatory: Boolean!
+  questionPageId: ID!
+}
+
+input UpdateAnswerInput {
+  id: ID!
+  description: String
+  guidance: String
+  label: String
+  qCode: String
+  type: AnswerType
+  mandatory: Boolean
 }
 
 input DeleteAnswerInput {
-    id: ID!
+  id: ID!
 }
 
 input CreateOptionInput {
-    label: String
-    description: String
-    value: String
-    qCode: String
-    childAnswerId: ID
-    answerId: ID!
+  label: String
+  description: String
+  value: String
+  qCode: String
+  childAnswerId: ID
+  answerId: ID!
 }
 
 input UpdateOptionInput {
-    id: ID!
-    label: String
-    description: String
-    value: String
-    qCode: String
-    childAnswerId: ID
+  id: ID!
+  label: String
+  description: String
+  value: String
+  qCode: String
+  childAnswerId: ID
 }
 
 input DeleteOptionInput {
-    id: ID!
+  id: ID!
 }
+
 `;

--- a/index.js
+++ b/index.js
@@ -131,28 +131,148 @@ type Query {
 
 type Mutation {
     # creates a Questionnaire along with an initial Section and Page
-    createQuestionnaire(title: String!, description: String, theme: String!, legalBasis: LegalBasis!, navigation: Boolean, surveyId: String!) : Questionnaire
-    updateQuestionnaire(id: Int!, title: String, description: String, theme: String, legalBasis: LegalBasis, navigation: Boolean, surveyId: String) : Questionnaire
-    deleteQuestionnaire(id: Int!) : Questionnaire
+    createQuestionnaire(title: String, description: String, theme: String, legalBasis: LegalBasis, navigation: Boolean, surveyId: String, input: CreateQuestionnaireInput) : Questionnaire
+    updateQuestionnaire(id: Int, title: String, description: String, theme: String, legalBasis: LegalBasis, navigation: Boolean, surveyId: String, input: UpdateQuestionnaireInput) : Questionnaire
+    deleteQuestionnaire(id: Int, input: DeleteQuestionnaireInput) : Questionnaire
 
-    createSection(title: String!, description: String, questionnaireId: Int!) : Section
-    updateSection(id: Int!, title: String, description: String) : Section
-    deleteSection(id: Int!) : Section
+    createSection(title: String, description: String, questionnaireId: Int, input: CreateSectionInput) : Section
+    updateSection(id: Int, title: String, description: String, input: UpdateSectionInput) : Section
+    deleteSection(id: Int, input: DeleteSectionInput) : Section
 
-    createPage(title: String!, description: String, sectionId: Int!) : Page
-    updatePage(id: Int!, title: String!, description: String) : Page
-    deletePage(id: Int!) : Page
+    createPage(title: String, description: String, sectionId: Int, input: CreatePageInput) : Page
+    updatePage(id: Int, title: String, description: String, input: UpdatePageInput) : Page
+    deletePage(id: Int, input: DeletePageInput) : Page
 
-    createQuestionPage(title: String!, description: String, guidance: String, sectionId: Int!) : QuestionPage
-    updateQuestionPage(id: Int!, title: String, description: String, guidance: String) : QuestionPage
-    deleteQuestionPage(id: Int!) : QuestionPage
+    createQuestionPage(title: String, description: String, guidance: String, sectionId: Int, input: CreateQuestionPageInput) : QuestionPage
+    updateQuestionPage(id: Int, title: String, description: String, guidance: String, input: UpdateQuestionPageInput) : QuestionPage
+    deleteQuestionPage(id: Int, input: DeleteQuestionPageInput) : QuestionPage
 
-    createAnswer(description: String, guidance: String, label: String, qCode: String, type: AnswerType!, mandatory: Boolean!, questionPageId: Int!) : Answer
-    updateAnswer(id: Int!, description: String, guidance: String, label: String, qCode: String, type: AnswerType, mandatory: Boolean) : Answer
-    deleteAnswer(id: Int!) : Answer
+    createAnswer(description: String, guidance: String, label: String, qCode: String, type: AnswerType, mandatory: Boolean, questionPageId: Int, input: CreateAnswerInput) : Answer
+    updateAnswer(id: Int, description: String, guidance: String, label: String, qCode: String, type: AnswerType, mandatory: Boolean, input: UpdateAnswerInput) : Answer
+    deleteAnswer(id: Int, input: DeleteAnswerInput) : Answer
     
-    createOption(label: String, description: String, value: String, qCode: String, childAnswerId: Int, answerId: Int!) : Option
-    updateOption(id: Int!, label: String, description: String, value: String, qCode: String, childAnswerId: Int) : Option
-    deleteOption(id: Int!) : Option
+    createOption(label: String, description: String, value: String, qCode: String, childAnswerId: Int, answerId: Int, input: CreateOptionInput) : Option
+    updateOption(id: Int, label: String, description: String, value: String, qCode: String, childAnswerId: Int, input: UpdateOptionInput) : Option
+    deleteOption(id: Int, input: DeleteOptionInput) : Option
+}
+
+
+input CreateQuestionnaireInput {
+    title: String!
+    description: String
+    theme: String!
+    legalBasis: LegalBasis!
+    navigation: Boolean
+    surveyId: String!
+}
+
+input UpdateQuestionnaireInput {
+    id: ID!
+    title: String
+    description: String
+    theme: String
+    legalBasis: LegalBasis
+    navigation: Boolean
+    surveyId: String
+}
+
+input DeleteQuestionnaireInput {
+    id: ID!
+}
+
+input CreateSectionInput {
+    title: String!
+    description: String
+    questionnaireId: ID!
+}
+
+input UpdateSectionInput {
+    id: ID!
+    title: String
+    description: String
+}
+
+input DeleteSectionInput {
+    id: ID!
+}
+
+input CreatePageInput {
+    title: String!
+    description: String
+    sectionId: ID!
+}
+
+input UpdatePageInput {
+    id: ID!
+    title: String!
+    description: String
+}
+
+input DeletePageInput {
+    id: ID!
+}
+
+input CreateQuestionPageInput {
+    title: String!
+    description: String
+    guidance: String
+    sectionId: ID!
+}
+
+input UpdateQuestionPageInput {
+    id: ID!
+    title: String
+    description: String
+    guidance: String
+}
+
+input DeleteQuestionPageInput {
+    id: ID!
+}
+
+input CreateAnswerInput {
+    description: String
+    guidance: String
+    label: String
+    qCode: String
+    type: AnswerType!
+    mandatory: Boolean!
+    questionPageId: ID!
+}
+
+input UpdateAnswerInput {
+    id: ID!
+    description: String
+    guidance: String
+    label: String
+    qCode: String
+    type: AnswerType
+    mandatory: Boolean
+}
+
+input DeleteAnswerInput {
+    id: ID!
+}
+
+input CreateOptionInput {
+    label: String
+    description: String
+    value: String
+    qCode: String
+    childAnswerId: ID
+    answerId: ID!
+}
+
+input UpdateOptionInput {
+    id: ID!
+    label: String
+    description: String
+    value: String
+    qCode: String
+    childAnswerId: ID
+}
+
+input DeleteOptionInput {
+    id: ID!
 }
 `;


### PR DESCRIPTION
### What is the context of this PR?
improves our graphql usage in a number of ways:

* **use `ID` type for entity identifiers**
  * to avoid breaking changes, a new field `newId` of type `ID` has been introduced
  * this can be consumed on the front-end as an intermediate step
  * when API and front-end are deployed, subsequent task is needed to update the old `id` field (since front-end is no longer using it) to use `ID` type. We can then deprecate/drop `newId`.
* **Use input types for mutations**
  * it is considered best practice to use a single input types for a mutation
  * this makes it easier to extend/deprecate parts of a mutation in future
  * this PR introduces input types for all mutations
  * to make backwards compatible, all previous arguments to mutations are made optional
* **cleans up old deprecated fields**
   * there were a bunch of deprecated fields that are no longer consumed by any clients, so they were safe to delete

### How to review 
sanity check changes