### PR TITLE
drop version to 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,3 @@
 # eq-author-graphql-schema
 
 GraphQL type definitions and schema for [eq-author](https://github.com/ONSdigital/eq-author).
-
-
-## Changelog
-
-### 1.0.0
-
-- Deprecated use of `group`.
-- Mutations and queries related to `group` have also been deprecated.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eq-author-graphql-schema",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "The GraphQL schema for the eq-author application.",
   "main": "index.js",
   "repository": "git@github.com:ONSdigital/eq-author-graphql-schema.git",


### PR DESCRIPTION
### What is the context of this PR?
Changes to version number in package.json to pre v1.0. This is to indicate that it is beta software and subject to change (as per semver). 

Also removed changelog, since it didn't make sense that we were going backwards through versions (and the one change that was listed it not significant now).

### How to review 
Give it a once over
