### PR TITLE
whitelist files to be published

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "eq-author-graphql-schema",
   "version": "0.1.0",
+  "files": ["index.js"],
   "description": "The GraphQL schema for the eq-author application.",
   "main": "index.js",
   "repository": "git@github.com:ONSdigital/eq-author-graphql-schema.git",


### PR DESCRIPTION
### What is the context of this PR?
Whitelists files that should be published to npm. It is preferable to use a whitelist over a blacklist (`.npmignore`) so that you don't accidentally publish files that shouldn't be published

### How to review 
Use the `npm pack` command to create a tarball, which is exactly what would be published. You can view its content by running:

```bash
tar -tf eq-author-graphql-schema-0.1.0.tgz
```

This will list the files in the tarball. You should see `index.js` listed. Note that `package.json` and `README(.md)` are always included in a package, so you will see those listed too. 