### PR TITLE
Add summary property to Questionnaire in the GraphQL schema.

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ type Questionnaire {
   surveyId: String
   createdAt: Date
   sections: [Section]
+  summary: Boolean
 }
 
 type Section {
@@ -165,6 +166,7 @@ input CreateQuestionnaireInput {
   legalBasis: LegalBasis!
   navigation: Boolean
   surveyId: String!
+  summary: Boolean
 }
 
 input UpdateQuestionnaireInput {
@@ -175,6 +177,7 @@ input UpdateQuestionnaireInput {
   legalBasis: LegalBasis
   navigation: Boolean
   surveyId: String
+  summary: Boolean
 }
 
 input DeleteQuestionnaireInput {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eq-author-graphql-schema",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "files": [
     "index.js"
   ],


### PR DESCRIPTION
### What is the context of this PR?
This PR adds a `summary` property to the Questionnaire type in the GraphQL schema.
It also bumps the version to 0.4.0

### How to review 
Sanity check the change.
