### PR TITLE
Bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "name": "eq-author-graphql-schema",
-  "version": "0.4.0",
-  "files": ["index.js"],
+  "version": "0.5.0",
+  "files": [
+    "index.js"
+  ],
   "description": "The GraphQL schema for the eq-author application.",
   "main": "index.js",
   "repository": "git@github.com:ONSdigital/eq-author-graphql-schema.git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "dependencies": {},
   "scripts": {
-    "postversion": "git push && git push --tags",
+    "postversion": "git push origin head && git push --tags",
     "test": "./scripts/build.js"
   },
   "devDependencies": {


### PR DESCRIPTION
### What is the context of this PR?
bumps version to `v0.5.0` ahead of publish to npm

### How to review 
build passes, everything looks good