### PR TITLE
Replace childAnswerId on Option with otherAnswer on MultipleChoiceAnswer.

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,6 +78,7 @@ type MultipleChoiceAnswer implements Answer {
   type: AnswerType!
   mandatory: Boolean
   options: [Option]
+  hasOtherOption: Boolean
   page: QuestionPage
 }
 
@@ -259,6 +260,7 @@ input CreateAnswerInput {
   qCode: String
   type: AnswerType!
   mandatory: Boolean!
+  hasOtherOption: Boolean
   questionPageId: ID!
 }
 
@@ -269,6 +271,7 @@ input UpdateAnswerInput {
   label: String
   qCode: String
   type: AnswerType
+  hasOtherOption: Boolean
   mandatory: Boolean
 }
 

--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ type MultipleChoiceAnswer implements Answer {
   type: AnswerType!
   mandatory: Boolean
   options: [Option]
-  other: Answer
+  otherAnswer: Answer
   page: QuestionPage
 }
 
@@ -260,7 +260,7 @@ input CreateAnswerInput {
   qCode: String
   type: AnswerType!
   mandatory: Boolean!
-  other: Answer
+  otherAnswerId: ID
   questionPageId: ID!
 }
 
@@ -271,7 +271,7 @@ input UpdateAnswerInput {
   label: String
   qCode: String
   type: AnswerType
-  other: Answer
+  otherAnswerId: ID
   mandatory: Boolean
 }
 

--- a/index.js
+++ b/index.js
@@ -87,7 +87,6 @@ type Option {
   description: String
   value: String
   qCode: String
-  childAnswerId: Int
   answer: Answer
 }
 
@@ -286,7 +285,6 @@ input CreateOptionInput {
   description: String
   value: String
   qCode: String
-  childAnswerId: ID
   answerId: ID!
 }
 
@@ -296,7 +294,6 @@ input UpdateOptionInput {
   description: String
   value: String
   qCode: String
-  childAnswerId: ID
 }
 
 input DeleteOptionInput {

--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ type MultipleChoiceAnswer implements Answer {
   type: AnswerType!
   mandatory: Boolean
   options: [Option]
-  hasOtherOption: Boolean
+  other: Answer
   page: QuestionPage
 }
 
@@ -260,7 +260,7 @@ input CreateAnswerInput {
   qCode: String
   type: AnswerType!
   mandatory: Boolean!
-  hasOtherOption: Boolean
+  other: Answer
   questionPageId: ID!
 }
 
@@ -271,7 +271,7 @@ input UpdateAnswerInput {
   label: String
   qCode: String
   type: AnswerType
-  hasOtherOption: Boolean
+  other: Answer
   mandatory: Boolean
 }
 

--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ type MultipleChoiceAnswer implements Answer {
   type: AnswerType!
   mandatory: Boolean
   options: [Option]
-  otherAnswer: Answer
+  otherAnswer: BasicAnswer
   page: QuestionPage
 }
 
@@ -157,6 +157,8 @@ type Mutation {
   updateOption(input: UpdateOptionInput!): Option
   deleteOption(input: DeleteOptionInput!): Option
   undeleteOption(input: UndeleteOptionInput!): Option
+  createOtherAnswer(input: CreateOtherAnswerInput!): Answer
+  deleteOtherAnswer(input: DeleteOtherAnswerInput!): Answer
 }
 
 input CreateQuestionnaireInput {
@@ -260,7 +262,6 @@ input CreateAnswerInput {
   qCode: String
   type: AnswerType!
   mandatory: Boolean!
-  otherAnswerId: ID
   questionPageId: ID!
 }
 
@@ -271,7 +272,6 @@ input UpdateAnswerInput {
   label: String
   qCode: String
   type: AnswerType
-  otherAnswerId: ID
   mandatory: Boolean
 }
 
@@ -312,4 +312,14 @@ input MovePageInput {
   sectionId: ID!
   position: Int!
 }
+
+input CreateOtherAnswerInput {
+  id: ID!
+  type: AnswerType!
+}
+
+input DeleteOtherAnswerInput {
+  id: ID!
+}
+
 `;

--- a/index.js
+++ b/index.js
@@ -314,12 +314,11 @@ input MovePageInput {
 }
 
 input CreateOtherAnswerInput {
-  id: ID!
-  type: AnswerType!
+  parentAnswerId: ID!
 }
 
 input DeleteOtherAnswerInput {
-  id: ID!
+  parentAnswerId: ID!
 }
 
 `;


### PR DESCRIPTION
### What is the context of this PR?
It was felt that the `childAnswerId` should not really be the concern of Author and is more of an implementation detail of Survey Runner.

This PR removes childAnswerId attribute from the Option type in the GraphQL schema and replaces it instead with a hasOtherOption Boolean attribute on the parent (Multiple choice answer).

### Dependencies
This PR depends on changes to Author API and Publisher (PRs will be raised for these projects and linked below once they exist.

### How to review 
Ensure that the changes to the GraphQL schema are sensible.