### PR TITLE
Add other field on multiple choice answer that wraps "other" option and answer.

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ type MultipleChoiceAnswer implements Answer {
   type: AnswerType!
   mandatory: Boolean
   options: [Option]
-  otherAnswer: BasicAnswer
+  other: Other
   page: QuestionPage
 }
 
@@ -91,6 +91,11 @@ type Option {
   value: String
   qCode: String
   answer: Answer
+}
+
+type Other {
+  otherOption: Option!
+  otherAnswer: BasicAnswer!
 }
 
 type RoutingRuleSet {

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ type MultipleChoiceAnswer implements Answer {
   type: AnswerType!
   mandatory: Boolean
   options: [Option]
-  other: Other
+  other: OptionWithAnswer
   page: QuestionPage
 }
 
@@ -93,9 +93,9 @@ type Option {
   answer: Answer
 }
 
-type Other {
-  otherOption: Option!
-  otherAnswer: BasicAnswer!
+type OptionWithAnswer {
+  option: Option!
+  answer: BasicAnswer!
 }
 
 type RoutingRuleSet {


### PR DESCRIPTION
### What is the context of this PR?
Previously a new otherAnswer field was introduced in order to allow querying of the child answer (TextField) from the parent answer (Radio or Checkbox).

The Publisher was then responsible for dynamically generating the Other option. However, there's a requirement to be able to modify the "other" Option's label. So this isn't something that can be generated dynamically anymore.

This PR introduces a new GraphQL type, Other, that wraps the Option and the Answer field. Another PR will be raised in turn to resolve the correct Option and Answer instances in the API.

### How to review 
Should be valid GraphQL schema and the changes should look sensible.
