### PR TITLE
Update GraphQL schema to return OptionWithAnswer on create/delete other.

### DIFF
--- a/index.js
+++ b/index.js
@@ -207,8 +207,8 @@ type Mutation {
   updateOption(input: UpdateOptionInput!): Option
   deleteOption(input: DeleteOptionInput!): Option
   undeleteOption(input: UndeleteOptionInput!): Option
-  createOtherAnswer(input: CreateOtherAnswerInput!): Answer
-  deleteOtherAnswer(input: DeleteOtherAnswerInput!): Answer
+  createOther(input: CreateOtherInput!): OptionWithAnswer
+  deleteOther(input: DeleteOtherInput!): OptionWithAnswer
   createRoutingRuleSet(input: CreateRoutingRuleSetInput!): RoutingRuleSet
   updateRoutingRuleSet(input: UpdateRoutingRuleSetInput!): RoutingRuleSet
   deleteRoutingRuleSet(input: DeleteRoutingRuleSetInput!): RoutingRuleSet
@@ -374,11 +374,11 @@ input MovePageInput {
   position: Int!
 }
 
-input CreateOtherAnswerInput {
+input CreateOtherInput {
   parentAnswerId: ID!
 }
 
-input DeleteOtherAnswerInput {
+input DeleteOtherInput {
   parentAnswerId: ID!
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eq-author-graphql-schema",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "files": [
     "index.js",
     "fragmentTypes.json"


### PR DESCRIPTION
### What is the context of this PR?
While integrating the add/remove "other" answer feature into the Author application. It became apparent that the option and answer need to be returned from the API as a pair in order to make it easier to update the Apollo store on mutation.

This PR renames the mutations and input types to reflect the fact that they will no longer return just the answer.

### How to review 
Changes look sensible.
Changes will be pushed to the open PR on the API to reflect these changes in the API.
