### PR TITLE
Add mutation to delete a routing rule set by Id.

### DIFF
--- a/index.js
+++ b/index.js
@@ -215,6 +215,7 @@ type Mutation {
   deleteOther(input: DeleteOtherInput!): OptionWithAnswer
   createRoutingRuleSet(input: CreateRoutingRuleSetInput!): RoutingRuleSet
   updateRoutingRuleSet(input: UpdateRoutingRuleSetInput!): RoutingRuleSet
+  deleteRoutingRuleSet(input: DeleteRoutingRuleSetInput!): RoutingRuleSet
   resetRoutingRuleSetElse(input: ResetRoutingRuleSetElseInput!): RoutingRuleSet
   createRoutingRule(input: CreateRoutingRuleInput!): RoutingRule
   updateRoutingRule(input: UpdateRoutingRuleInput!): RoutingRule
@@ -395,6 +396,10 @@ input CreateRoutingRuleSetInput {
 input UpdateRoutingRuleSetInput {
   id: ID!
   else: RoutingDestinationInput!
+}
+
+input DeleteRoutingRuleSetInput {
+  id: ID!
 }
 
 input ResetRoutingRuleSetElseInput {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eq-author-graphql-schema",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "files": [
     "index.js",
     "fragmentTypes.json"


### PR DESCRIPTION
### What is the context of this PR?
This PR adds a new mutation `deleteRoutingRuleSet` and an associated input type `DeleteRoutingRuleSetInput`.

This new mutation is required for deleting the routing rule set associated with a question page in the event that the last routing rule is deleted.

Deleting the routing rule set, allows the routing to reset itself to it's empty state.

### How to review 
Change to the GraphQL looks sensible.
