### PR TITLE
Update schema for logical and absolute routing destinations.

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ type RoutingRule {
 
 enum LogicalDestinations {
   NextPage
-  EndOfQuestionnnaire
+  EndOfQuestionnaire
 }
 
 enum AbsoluteDestinationTypes {
@@ -129,15 +129,15 @@ enum AbsoluteDestinationTypes {
 
 union AbsoluteDestinations = QuestionPage | Section
 
-type AbsoluteDesintation {
-  destination: AbsoluteDestinations!
+type AbsoluteDestination {
+  absoluteDestination: AbsoluteDestinations!
 }
 
 type LogicalDestination {
-  destination: LogicalDestinations!
+  logicalDestination: LogicalDestinations!
 }
 
-union RoutingDestination = AbsoluteDesintation | LogicalDestination
+union RoutingDestination = AbsoluteDestination | LogicalDestination
 
 type RoutingCondition {
   id: ID!
@@ -429,7 +429,6 @@ input ResetRoutingRuleSetElseInput {
 input CreateRoutingRuleInput {
   operation: RoutingOperation!
   routingRuleSetId: ID!
-  goto: RoutingDestinationInput
 }
 
 input UpdateRoutingRuleInput {

--- a/index.js
+++ b/index.js
@@ -154,11 +154,11 @@ type RoutingCondition {
   routingValue: RoutingConditionValue
 }
 
-type IDArrayValue {
-  value: [ID]
+type IDValue {
+  value: ID
 }
 
-union RoutingConditionValue = IDArrayValue
+union RoutingConditionValue = IDValue
 
 enum RoutingOperation {
   And
@@ -166,8 +166,7 @@ enum RoutingOperation {
 }
 
 enum RoutingComparator {
-  Equal,
-  NotEqual
+  Equal
 }
 
 enum PageType {
@@ -251,7 +250,7 @@ type Mutation {
   createRoutingCondition(input: CreateRoutingConditionInput!): RoutingCondition
   updateRoutingCondition(input: UpdateRoutingConditionInput!): RoutingCondition
   deleteRoutingCondition(input: DeleteRoutingConditionInput!): RoutingCondition
-  toggleConditionOption(input: ToggleConditionOptionInput!): RoutingConditionValue
+  updateRoutingConditionValue(input: UpdateRoutingConditionValueInput!): RoutingConditionValue
 }
 
 input CreateQuestionnaireInput {
@@ -469,10 +468,9 @@ input DeleteRoutingConditionInput {
   id: ID!
 }
 
-input ToggleConditionOptionInput {
-  optionId: ID!
+input UpdateRoutingConditionValueInput {
+  optionId: ID
   conditionId: ID!
-  checked: Boolean!
 }
 
 input LogicalDestinationInput {

--- a/index.js
+++ b/index.js
@@ -139,6 +139,12 @@ type LogicalDestination {
 
 union RoutingDestination = AbsoluteDestination | LogicalDestination
 
+type AvailableRoutingDestinations {
+  logicalDestinations: [LogicalDestination]!
+  questionPages: [QuestionPage]!
+  sections: [Section]!
+}
+
 type RoutingCondition {
   id: ID!
   comparator: RoutingComparator
@@ -202,7 +208,7 @@ type Query {
   answers(ids: [ID]!): [Answer]
   option(id: ID!): Option
   pagesAffectedByDeletion(pageId: ID!): [Page]!
-  availableRoutingDestinations(pageId: ID!): [RoutingDestination]!
+  availableRoutingDestinations(pageId: ID!): AvailableRoutingDestinations!
 }
 
 type Mutation {

--- a/index.js
+++ b/index.js
@@ -134,6 +134,7 @@ type AbsoluteDestination {
 }
 
 type LogicalDestination {
+  id: ID!
   logicalDestination: LogicalDestinations!
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eq-author-graphql-schema",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "files": [
     "index.js",
     "fragmentTypes.json"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eq-author-graphql-schema",
-  "version": "0.14.4",
+  "version": "0.15.0",
   "files": [
     "index.js",
     "fragmentTypes.json"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eq-author-graphql-schema",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "files": [
     "index.js",
     "fragmentTypes.json"


### PR DESCRIPTION
### What is the context of this PR?
This PR fixes some typos that were discovered in the GraphQL schema.
It also introduces a new result type for the `availableRoutingDestinations` query.
This new result type helps to provide some structure for the format of the results, splitting the destinations out into logical destinations, question pages and sections.

### How to review 
Spelling corrections have been made.
New type for available routing destination look sensible.
New patch version of schema created for npm.
