### PR TITLE
Add ability for questionnaire to get to all others

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ type Questionnaire {
   summary: Boolean
   questionnaireInfo: QuestionnaireInfo
   metadata: [Metadata!]!
+  questionnaires: [Questionnaire!]!
 }
 
 type Section {


### PR DESCRIPTION
### What is the context of this PR?
When duplicating a questionnaire you need to be able to get a list of all other questionnaires to know where the knew one went (the order is controlled by the server).

### How to review 
1. Look at schema change and see if you agree with the approach.
