### PR TITLE
Edited the script to allow for deperecated fields to be removed

### DIFF
--- a/scripts/findBreakingChanges.js
+++ b/scripts/findBreakingChanges.js
@@ -3,7 +3,9 @@ const {
   findBreakingChanges,
   isObjectType,
   isInterfaceType,
-  BreakingChangeType
+  BreakingChangeType,
+  isInputObjectType,
+  isEnumType
 } = require("graphql");
 
 const tail = ([, ...rest]) => rest;
@@ -11,6 +13,12 @@ const re = re => data => re.exec(data);
 const flow = (...fns) => arg => fns.reduce((acc, fn) => fn(acc), arg);
 const get = prop => obj => obj[prop];
 const startsWith = needle => haystack => haystack.indexOf(needle) === 0;
+
+const parseEnumBreakage = data => {
+  const stripFullStops = /\./g;
+  const words = data.replace(stripFullStops, "").split(" ");
+  return [words[0], words[words.length - 1]];
+};
 
 const isIntrospectionType = flow(
   get("name"),
@@ -22,6 +30,17 @@ const parseBreakage = flow(
   tail
 );
 
+const findDeprecatedDirective = directives => {
+  if (directives.length === 0) {
+    return false;
+  } else {
+    const deprecatedDirectives = directives.filter(
+      directive => directive.name.value === "deprecated"
+    );
+    return deprecatedDirectives.length > 0 ? true : false;
+  }
+};
+
 const findDeprecatedFields = schema => {
   const deprecatedFields = [];
   const typeMap = schema.getTypeMap();
@@ -30,41 +49,79 @@ const findDeprecatedFields = schema => {
     const type = typeMap[typeName];
 
     if (
-      !(isObjectType(type) || isInterfaceType(type)) ||
+      !(
+        isObjectType(type) ||
+        isInterfaceType(type) ||
+        isInputObjectType(type) ||
+        isEnumType(type)
+      ) ||
       isIntrospectionType(type)
     ) {
       return;
     }
 
-    const fields = type.getFields();
+    if (isEnumType(type)) {
+      const values = type.getValues();
+      values.map(value => {
+        if (value.isDeprecated) {
+          deprecatedFields.push({
+            field: value.name,
+            type: type.toString()
+          });
+        }
+      });
+    } else {
+      const fields = type.getFields();
 
-    Object.keys(fields).forEach(fieldName => {
-      const field = fields[fieldName];
-
-      if (field.isDeprecated) {
-        deprecatedFields.push({
-          field: fieldName,
-          type: typeName
-        });
-      }
-    });
+      Object.keys(fields).forEach(fieldName => {
+        const field = fields[fieldName];
+        if (
+          field.isDeprecated ||
+          findDeprecatedDirective(field.astNode.directives)
+        ) {
+          deprecatedFields.push({
+            field: fieldName,
+            type: typeName
+          });
+        }
+        if (field.hasOwnProperty("args") && field.args.length > 0) {
+          field.args.map(arg => {
+            if (findDeprecatedDirective(arg.astNode.directives)) {
+              deprecatedFields.push({
+                field: fieldName,
+                type: typeName
+              });
+            }
+          });
+        }
+      });
+    }
   });
-
   return deprecatedFields;
 };
 
 const filterOutDeprecatedFields = (breakages, deprecated) => {
   return breakages.filter(breakage => {
-    if (breakage.type !== BreakingChangeType.FIELD_REMOVED) {
-      return true;
+    if (
+      [
+        BreakingChangeType.FIELD_REMOVED,
+        BreakingChangeType.ARG_REMOVED,
+        BreakingChangeType.VALUE_REMOVED_FROM_ENUM
+      ].includes(breakage.type)
+    ) {
+      let type, field;
+      if (breakage.type === BreakingChangeType.VALUE_REMOVED_FROM_ENUM) {
+        [field, type] = parseEnumBreakage(get("description")(breakage));
+      } else {
+        [type, field] = parseBreakage(breakage);
+      }
+      const isDeprecatedField = deprecated.some(
+        x => x.type === type && x.field === field
+      );
+
+      return !isDeprecatedField;
     }
-
-    const [type, field] = parseBreakage(breakage);
-    const isDeprecatedField = deprecated.some(
-      x => x.type === type && x.field === field
-    );
-
-    return !isDeprecatedField;
+    return true;
   });
 };
 


### PR DESCRIPTION
### What is the context of this PR?
This PR alters the script used to test for breaking changes and allows us to remove deprecated arguments, enums, inputs and types.

### How to review 
Schema is backwards compatible and deprecated fields can be removed without causing a breaking change.
