### PR TITLE
Make schema changes comparison more reliable by comparing with origin…

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -8,7 +8,7 @@ const fs = require("fs");
 const findBreakingChanges = require("./findBreakingChanges");
 
 const getMasterSchema = () => {
-  childProcess.execSync("git show master:index.js > ./scripts/temp.js");
+  childProcess.execSync("git show origin/master:index.js > ./scripts/temp.js");
   const schema = require("./temp.js");
   fs.unlinkSync("./scripts/temp.js");
 


### PR DESCRIPTION
### What is the context of this PR?
Compare schema changes with `origin/master` rather than `master` as it's more reliable

### How to review 
- Run tests